### PR TITLE
Release 12.22.1 -- replace MFA API URLs with one variable

### DIFF
--- a/terraform/040-id-broker/main.tf
+++ b/terraform/040-id-broker/main.tf
@@ -168,10 +168,10 @@ locals {
     mfa_manager_bcc                            = var.mfa_manager_bcc
     mfa_manager_help_bcc                       = var.mfa_manager_help_bcc
     mfa_required_for_new_users                 = var.mfa_required_for_new_users
-    mfa_totp_apibaseurl                        = var.mfa_totp_apibaseurl
+    mfa_totp_apibaseurl                        = coalesce(var.mfa_api_base_url, var.mfa_totp_apibaseurl)
     mfa_totp_apikey                            = var.mfa_totp_apikey
     mfa_totp_apisecret                         = var.mfa_totp_apisecret
-    mfa_webauthn_apibaseurl                    = var.mfa_webauthn_apibaseurl
+    mfa_webauthn_apibaseurl                    = coalesce(var.mfa_api_base_url, var.mfa_webauthn_apibaseurl)
     mfa_webauthn_apikey                        = var.mfa_webauthn_apikey
     mfa_webauthn_apisecret                     = var.mfa_webauthn_apisecret
     mfa_webauthn_appid                         = var.mfa_webauthn_appid

--- a/terraform/040-id-broker/vars.tf
+++ b/terraform/040-id-broker/vars.tf
@@ -337,6 +337,15 @@ variable "mfa_allow_disable" {
   default = "true"
 }
 
+variable "mfa_api_base_url" {
+  description = <<-EOT
+    The base URL of the MFA API. Must include the scheme and a trailing slash. Replaces `mfa_totp_apibaseurl` and
+    `mfa_webauthn_apibaseurl`.
+  EOT
+  type        = string
+  default     = ""
+}
+
 variable "mfa_lifetime" {
   type    = string
   default = "+2 hours"
@@ -358,7 +367,9 @@ variable "mfa_required_for_new_users" {
 }
 
 variable "mfa_totp_apibaseurl" {
-  type = string
+  description = "DEPRECATED: use `mfa_api_base_url`"
+  type        = string
+  default     = ""
 }
 
 variable "mfa_totp_apikey" {
@@ -374,7 +385,9 @@ variable "mfa_totp_apisecret" {
 }
 
 variable "mfa_webauthn_apibaseurl" {
-  type = string
+  description = "DEPRECATED: use `mfa_api_base_url`"
+  type        = string
+  default     = ""
 }
 
 variable "mfa_webauthn_apikey" {


### PR DESCRIPTION
[IDP-1561](https://support.gtis.sil.org/issue/IDP-1561) add TOTP capability to serverless-mfa-api-go

---

### Added
- Added `mfa_api_base_url` variable to replace `mfa_totp_apibaseurl` and `mfa_webauthn_apibaseurl` variables.

### Deprecated
- Deprecated `mfa_totp_apibaseurl` and `mfa_webauthn_apibaseurl` variables.
