### PR TITLE
Release 13.0.0-pre.1 -- re-add nat_gateway_ip

### DIFF
--- a/terraform/010-cluster/README.md
+++ b/terraform/010-cluster/README.md
@@ -38,6 +38,7 @@ ssl certificate, core application load balancer, and a CloudWatch log group
 ## Outputs
 
  - `db_subnet_group_name` - Database subnet group name
+ - `nat_gateway_ip` - IP Address of the NAT gateway
  - `private_subnet_ids` - List of private subnet ids in VPC
  - `private_subnet_cidr_blocks` - A list of private subnet CIDR blocks, ex: `["10.0.11.0/24","10.0.22.0/24"]`
  - `public_subnet_ids` - List of public subnet ids in VPC

--- a/terraform/010-cluster/outputs.tf
+++ b/terraform/010-cluster/outputs.tf
@@ -5,6 +5,14 @@ output "db_subnet_group_name" {
   value = module.vpc.db_subnet_group_name
 }
 
+output "nat_gateway_ip" {
+  description = <<-EOT
+    IP Address of the NAT gateway. Used to configure the firewall of any external service that uses
+    IP-based filtering and needs to be reached by the IdP.
+  EOT
+  value       = module.vpc.nat_gateway_ip
+}
+
 output "private_subnet_ids" {
   value = module.vpc.private_subnet_ids
 }


### PR DESCRIPTION

### Added
- Re-added the `nat_gateway_ip` output because it is used in failover documents.